### PR TITLE
Allow first character of a hostsfile entry to be numeric

### DIFF
--- a/hosts.net/Parsing/HostsFileEntry.cs
+++ b/hosts.net/Parsing/HostsFileEntry.cs
@@ -189,7 +189,7 @@ internal static class HostEntry
                 if(!char.IsAscii(c)) return true;
                 return (c != '-' && c != '.' && !IsAlphaNum(c));
             })) return false;
-        if (!char.IsLetter(name[0]) || !IsAlphaNum(name[^1]))
+        if (!char.IsAlphaNum(name[0]) || !IsAlphaNum(name[^1]))
         {
             return false;
         }

--- a/hosts.net/Parsing/HostsFileEntry.cs
+++ b/hosts.net/Parsing/HostsFileEntry.cs
@@ -176,7 +176,7 @@ internal static class HostEntry
     /// <summary>
     /// According to man7
     /// Host names may contain only alphanumeric characters, minus signs ("-"), and periods (".").
-    /// They must begin with an alphabetic character and end with an alphanumeric character.
+    /// They must begin with an alphanumeric character and end with an alphanumeric character. (Relaxed in RFC1123)
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>


### PR DESCRIPTION
I ran into a problem using your hosts library, in our use case, we have hosts that start with a number, this is valid in the hosts.etc file, I was wondering if you'll consider this pull request to fix