### PR TITLE
Update hostname check to use .NET API (more thorough) - checks for underscore, and splits the hostname into parts to validate things abba._invalid.com vs abba.is_valid.com

### DIFF
--- a/hosts.net/Parsing/HostsFileEntry.cs
+++ b/hosts.net/Parsing/HostsFileEntry.cs
@@ -182,19 +182,7 @@ internal static class HostEntry
     /// <returns></returns>
     public static bool IsValidHostname(string value)
     {
-        var name = value.Trim(HostsFileEntry._trimChars);
-        if (!name.Any()) return false;
-        if (name.Any(c =>
-            {
-                if(!char.IsAscii(c)) return true;
-                return (c != '-' && c != '.' && !IsAlphaNum(c));
-            })) return false;
-        if (!IsAlphaNum(name[0]) || !IsAlphaNum(name[^1]))
-        {
-            return false;
-        }
-
-        return true;
+        return Uri.CheckHostName(value) != UriHostNameType.Unknown;
     }
     
     private static bool IsAlphaNum(char c)

--- a/hosts.net/Parsing/HostsFileEntry.cs
+++ b/hosts.net/Parsing/HostsFileEntry.cs
@@ -182,7 +182,7 @@ internal static class HostEntry
     /// <returns></returns>
     public static bool IsValidHostname(string value)
     {
-        return Uri.CheckHostName(value) != UriHostNameType.Unknown;
+        return Uri.CheckHostName(value) == UriHostNameType.Dns;
     }
     
     private static bool IsAlphaNum(char c)


### PR DESCRIPTION
sorry to bother you again, but I ran into an issue with underscores -- if we use the .NET API, it does a much more thorough job of checking (I tested a few cursory cases)